### PR TITLE
- improve error handling after recover from underrun

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -880,7 +880,7 @@ static int AlsaPlayRingbuffer(void)
 			snd_strerror(err));
 		    err = snd_pcm_recover(AlsaPCMHandle, err, 0);
 		    if (err >= 0) {
-			continue;
+			return 0;
 		    }
 		    Error(_("audio/alsa: snd_pcm_writei failed: %s\n"),
 			snd_strerror(err));

--- a/audio.c
+++ b/audio.c
@@ -148,6 +148,8 @@ static int AudioBufferTime = 336;	///< audio buffer time in ms
 #ifdef USE_AUDIO_THREAD
 static pthread_t AudioThread;		///< audio play thread
 static pthread_mutex_t AudioMutex;	///< audio condition mutex
+pthread_mutex_t PTS_mutex;		///< PTS mutex
+pthread_mutex_t ReadAdvance_mutex;	///< PTS mutex
 static pthread_cond_t AudioStartCond;	///< condition variable
 static char AudioThreadStop;		///< stop audio thread
 #else
@@ -860,6 +862,7 @@ static int AlsaPlayRingbuffer(void)
 #endif
 
 	for (;;) {
+	    pthread_mutex_lock(&ReadAdvance_mutex);
 	    if (AlsaUseMmap) {
 		err = snd_pcm_mmap_writei(AlsaPCMHandle, p, frames);
 	    } else {
@@ -868,6 +871,7 @@ static int AlsaPlayRingbuffer(void)
 	    //Debug(3, "audio/alsa: wrote %d/%d frames\n", err, frames);
 	    if (err != frames) {
 		if (err < 0) {
+		    pthread_mutex_unlock(&ReadAdvance_mutex);
 		    if (err == -EAGAIN) {
 			continue;
 		    }
@@ -893,6 +897,7 @@ static int AlsaPlayRingbuffer(void)
 	    break;
 	}
 	RingBufferReadAdvance(AudioRing[AudioRingRead].RingBuffer, avail);
+	pthread_mutex_unlock(&ReadAdvance_mutex);
 	first = 0;
     }
 
@@ -963,7 +968,7 @@ static int AlsaThread(void)
 	}
 	break;
     }
-    if (!err || AudioPaused) {		// timeout or some commands
+    if (AudioPaused) {		// timeout or some commands
 	return 1;
     }
 
@@ -2186,6 +2191,8 @@ static void AudioInitThread(void)
 {
     AudioThreadStop = 0;
     pthread_mutex_init(&AudioMutex, NULL);
+    pthread_mutex_init(&PTS_mutex, NULL);
+    pthread_mutex_init(&ReadAdvance_mutex, NULL);
     pthread_cond_init(&AudioStartCond, NULL);
     pthread_create(&AudioThread, NULL, AudioPlayHandlerThread, NULL);
     pthread_setname_np(AudioThread, "softhddev audio");
@@ -2209,6 +2216,8 @@ static void AudioExitThread(void)
 	}
 	pthread_cond_destroy(&AudioStartCond);
 	pthread_mutex_destroy(&AudioMutex);
+	pthread_mutex_destroy(&PTS_mutex);
+	pthread_mutex_destroy(&ReadAdvance_mutex);
 	AudioThread = 0;
     }
 }
@@ -2304,6 +2313,7 @@ void AudioEnqueue(const void *samples, int count)
 	}
     }
 
+    pthread_mutex_lock(&PTS_mutex);
     n = RingBufferWrite(AudioRing[AudioRingWrite].RingBuffer, buffer, count);
     if (n != (size_t) count) {
 	Error(_("audio: can't place %d samples in ring buffer\n"), count);
@@ -2355,6 +2365,7 @@ void AudioEnqueue(const void *samples, int count)
 	    / (AudioRing[AudioRingWrite].HwSampleRate *
 	    AudioRing[AudioRingWrite].HwChannels * AudioBytesProSample);
     }
+    pthread_mutex_unlock(&PTS_mutex);
 }
 
 /**

--- a/softhddev.c
+++ b/softhddev.c
@@ -3539,3 +3539,8 @@ int PipPlayVideo(const uint8_t * data, int size)
 }
 
 #endif
+
+int IsReplay(void)
+{
+    return !AudioSyncStream || AudioSyncStream->ClearClose;
+}

--- a/video.c
+++ b/video.c
@@ -493,6 +493,8 @@ static pthread_t VideoThread;		///< video decode thread
 static pthread_cond_t VideoWakeupCond;	///< wakeup condition variable
 static pthread_mutex_t VideoMutex;	///< video condition mutex
 static pthread_mutex_t VideoLockMutex;	///< video lock mutex
+extern pthread_mutex_t PTS_mutex;	///< PTS mutex
+extern pthread_mutex_t ReadAdvance_mutex;	///< PTS mutex
 
 #endif
 
@@ -522,6 +524,10 @@ static int64_t VideoDeltaPTS;		///< FIXME: fix pts
 static char DPMSDisabled;		///< flag we have disabled dpms
 static char EnableDPMSatBlackScreen;	///< flag we should enable dpms at black screen
 #endif
+
+uint32_t mutex_start_time;
+int max_mutex_delay;
+max_mutex_delay = 1;
 
 //----------------------------------------------------------------------------
 //	Common Functions
@@ -6494,7 +6500,16 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
     int64_t video_clock;
 
     err = 0;
+    mutex_start_time = GetMsTicks();
+    pthread_mutex_lock(&PTS_mutex);
+    pthread_mutex_lock(&ReadAdvance_mutex);
     audio_clock = AudioGetClock();
+    pthread_mutex_unlock(&ReadAdvance_mutex);
+    pthread_mutex_unlock(&PTS_mutex);
+    if (GetMsTicks() - mutex_start_time > max_mutex_delay) {
+	max_mutex_delay = GetMsTicks() - mutex_start_time;
+	Debug(3, "video: mutex delay: %"PRIu32"ms\n", max_mutex_delay);
+    }
     video_clock = VaapiGetClock(decoder);
     filled = atomic_read(&decoder->SurfacesFilled);
 
@@ -10524,7 +10539,16 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 	// FIXME: 60Hz Mode
 	goto skip_sync;
     }
+    mutex_start_time = GetMsTicks();
+    pthread_mutex_lock(&PTS_mutex);
+    pthread_mutex_lock(&ReadAdvance_mutex);
     audio_clock = AudioGetClock();
+    pthread_mutex_unlock(&ReadAdvance_mutex);
+    pthread_mutex_unlock(&PTS_mutex);
+    if (GetMsTicks() - mutex_start_time > max_mutex_delay) {
+	max_mutex_delay = GetMsTicks() - mutex_start_time;
+	Debug(3, "video: mutex delay: %"PRIu32"ms\n", max_mutex_delay);
+    }
 
     // 60Hz: repeat every 5th field
     if (Video60HzMode && !(decoder->FramesDisplayed % 6)) {

--- a/video.c
+++ b/video.c
@@ -6552,18 +6552,24 @@ static void VaapiSyncDecoder(VaapiDecoder * decoder)
 	    // FIXME: this quicker sync step, did not work with new code!
 	    err = VaapiMessage(2, "video: slow down video, duping frame\n");
 	    ++decoder->FramesDuped;
-	    decoder->SyncCounter = 1;
-	    goto out;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+		goto out;
+	    }
 	} else if (diff > 55 * 90) {
 	    err = VaapiMessage(2, "video: slow down video, duping frame\n");
 	    ++decoder->FramesDuped;
-	    decoder->SyncCounter = 1;
-	    goto out;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+		goto out;
+	    }
 	} else if (diff < -25 * 90 && filled > 1 + 2 * decoder->Interlaced) {
 	    err = VaapiMessage(2, "video: speed up video, droping frame\n");
 	    ++decoder->FramesDropped;
 	    VaapiAdvanceDecoderFrame(decoder);
-	    decoder->SyncCounter = 1;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+	    }
 	}
 #if defined(DEBUG) || defined(AV_INFO)
 	if (!decoder->SyncCounter && decoder->StartCounter < 1000) {
@@ -10573,18 +10579,24 @@ static void VdpauSyncDecoder(VdpauDecoder * decoder)
 	    // FIXME: this quicker sync step, did not work with new code!
 	    err = VdpauMessage(2, "video: slow down video, duping frame\n");
 	    ++decoder->FramesDuped;
-	    decoder->SyncCounter = 1;
-	    goto out;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+		goto out;
+	    }
 	} else if (diff > 55 * 90) {
 	    err = VdpauMessage(2, "video: slow down video, duping frame\n");
 	    ++decoder->FramesDuped;
-	    decoder->SyncCounter = 1;
-	    goto out;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+		goto out;
+	    }
 	} else if (diff < -25 * 90 && filled > 1 + 2 * decoder->Interlaced) {
 	    err = VdpauMessage(2, "video: speed up video, droping frame\n");
 	    ++decoder->FramesDropped;
 	    VdpauAdvanceDecoderFrame(decoder);
-	    decoder->SyncCounter = 1;
+	    if (VideoSoftStartSync) {
+		decoder->SyncCounter = 1;
+	    }
 	}
 #if defined(DEBUG) || defined(AV_INFO)
 	if (!decoder->SyncCounter && decoder->StartCounter < 1000) {


### PR DESCRIPTION
in AlsaPlayRingbuffer() for faultless play after pause
- deactivate SyncCounter if no softstart